### PR TITLE
[KAIZEN-0] tvinge frem eksplisitt håndtering av token uthenting

### DIFF
--- a/ktor-utils/src/test/kotlin/no/nav/personoversikt/ktor/utils/SecurityTest.kt
+++ b/ktor-utils/src/test/kotlin/no/nav/personoversikt/ktor/utils/SecurityTest.kt
@@ -1,0 +1,81 @@
+package no.nav.personoversikt.ktor.utils
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.testing.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class SecurityTest {
+    @Test
+    internal fun `should use auth-header if present`() {
+        val call = createCall {
+            this.addHeader(HttpHeaders.Authorization, "Bearer headertoken")
+            this.addHeader(HttpHeaders.Cookie, "test=cookietoken;other=othertoken")
+        }
+        val security = Security(
+            Security.AuthProviderConfig(
+                name = null,
+                jwksUrl = "http://localhost.com",
+                tokenLocations = listOf(
+                    Security.TokenLocation.Cookie(name = "notfound"),
+                    Security.TokenLocation.Header(),
+                    Security.TokenLocation.Cookie(name = "test"),
+                )
+            )
+        )
+        val token = security.getToken(call)
+
+        assertEquals(listOf("Bearer headertoken"), token)
+    }
+
+    @Test
+    internal fun `should use first non-null cookie value`() {
+        val call = createCall {
+            this.addHeader(HttpHeaders.Authorization, "Bearer headertoken")
+            this.addHeader(HttpHeaders.Cookie, "test=cookietoken;other=othertoken")
+        }
+        val security = Security(
+            Security.AuthProviderConfig(
+                name = null,
+                jwksUrl = "http://localhost.com",
+                tokenLocations = listOf(
+                    Security.TokenLocation.Cookie(name = "notfound"),
+                    Security.TokenLocation.Cookie(name = "test"),
+                    Security.TokenLocation.Cookie(name = "other"),
+                )
+            )
+        )
+
+        val token = security.getToken(call)
+
+        assertEquals(listOf("Bearer cookietoken"), token)
+    }
+
+    @Test
+    internal fun `should use be able to get tokens for multiple providers`() {
+        val call = createCall {
+            this.addHeader(HttpHeaders.Authorization, "Bearer headertoken")
+            this.addHeader(HttpHeaders.Cookie, "test=cookietoken;other=othertoken")
+        }
+        val baseprovider = Security.AuthProviderConfig(
+            name = null,
+            jwksUrl = "http://localhost.com",
+            tokenLocations = emptyList()
+        )
+        val security = Security(
+            baseprovider.copy(tokenLocations = listOf(Security.TokenLocation.Header())),
+            baseprovider.copy(tokenLocations = listOf(Security.TokenLocation.Cookie(name = "test"))),
+            baseprovider.copy(tokenLocations = listOf(Security.TokenLocation.Cookie(name = "other"))),
+        )
+
+        val token = security.getToken(call)
+
+        assertEquals(listOf("Bearer headertoken", "Bearer cookietoken", "Bearer othertoken"), token)
+    }
+
+    private fun createCall(block: TestApplicationRequest.() -> Unit): ApplicationCall {
+        val engine = TestApplicationEngine()
+        return engine.createCall(setup = block)
+    }
+}


### PR DESCRIPTION
tidligere hentet vi implisitt alltid ut token fra Authorization-headeren først om den var satt. Som kan føre til at cookies blir oversett for visse providers (e.g isso). Eksponerer og tvinger derfor frem en eksplisitt håndtering av hvor appen skal titte etter cookies.

For å bevare funksjonaliteten fra tidligere må man derfor nå legge til `Security.TokenLocation.Header()` som første `tokenLocation`
