### PR TITLE
[KAIZEN-0] fjerne bruk av channel for rapportering av seltest-status

### DIFF
--- a/kotlin-utils/src/main/kotlin/no/nav/personoversikt/utils/SelftestGenerator.kt
+++ b/kotlin-utils/src/main/kotlin/no/nav/personoversikt/utils/SelftestGenerator.kt
@@ -1,38 +1,15 @@
 package no.nav.personoversikt.utils
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.receiveAsFlow
 
-@OptIn(DelicateCoroutinesApi::class)
-class SelftestGenerator(private val config: Config) {
+class SelftestGenerator private constructor(private var config: Config) {
     companion object {
-        private val statusmap = mutableMapOf<String, Event>()
-        private val channel = Channel<Event>(capacity = Channel.BUFFERED)
-        private var aggregator = GlobalScope.launch {
-            channel.receiveAsFlow().collect {
-                statusmap[it.reporter.name] = it
-            }
-        }
-
-        internal fun register(event: InitEvent) {
-            statusmap[event.reporter.name] = event
-        }
-
-        internal fun restart() {
-            statusmap.clear()
-            aggregator = GlobalScope.launch {
-                channel.receiveAsFlow().collect {
-                    statusmap[it.reporter.name] = it
-                }
-            }
-        }
-
-        fun stop() {
-            aggregator.cancel()
+        private var instance = SelftestGenerator(Config())
+        fun getInstance(config: Config): SelftestGenerator {
+            instance.config = config
+            return instance
         }
     }
-
     open class Config(
         var appname: String = "Not set",
         var version: String = "Not set",
@@ -42,6 +19,16 @@ class SelftestGenerator(private val config: Config) {
     class InitEvent(reporter: Reporter) : Event(reporter)
     class OkEvent(reporter: Reporter) : Event(reporter)
     class ErrorEvent(reporter: Reporter, val error: Throwable) : Event(reporter)
+
+    private val statusmap = mutableMapOf<String, Event>()
+
+    internal fun register(event: Event) {
+        statusmap[event.reporter.name] = event
+    }
+
+    internal fun clear() {
+        statusmap.clear()
+    }
 
     fun isAlive(): Boolean {
         return statusmap.values.none { it is ErrorEvent && it.reporter.critical }
@@ -70,20 +57,22 @@ class SelftestGenerator(private val config: Config) {
 
     class Reporter(val name: String, val critical: Boolean) {
         init {
-            register(InitEvent(this))
+            instance.register(InitEvent(this))
         }
 
-        suspend fun reportOk() {
-            channel.send(OkEvent(this))
+        fun reportOk() {
+            instance.register(OkEvent(this))
         }
 
-        suspend fun reportError(error: Throwable) {
-            channel.send(ErrorEvent(this, error))
+        fun reportError(error: Throwable) {
+            instance.register(ErrorEvent(this, error))
         }
 
-        suspend fun ping(fn: suspend () -> Unit) {
+        fun ping(fn: suspend () -> Unit) {
             try {
-                fn()
+                runBlocking(Dispatchers.IO) {
+                    fn()
+                }
                 reportOk()
             } catch (e: Throwable) {
                 reportError(e)

--- a/ktor-utils/src/main/kotlin/no/nav/personoversikt/ktor/utils/Selftest.kt
+++ b/ktor-utils/src/main/kotlin/no/nav/personoversikt/ktor/utils/Selftest.kt
@@ -2,7 +2,6 @@ package no.nav.personoversikt.ktor.utils
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.application.hooks.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.personoversikt.utils.SelftestGenerator
@@ -15,14 +14,9 @@ object Selftest {
     ) : SelftestGenerator.Config(appname, version)
 
     val Plugin = createApplicationPlugin("Selftest", { Config() }) {
-        val plugin = this
         val config = pluginConfig
-        val selftest = SelftestGenerator(pluginConfig)
+        val selftest = SelftestGenerator.getInstance(pluginConfig)
         with(application) {
-            plugin.on(MonitoringEvent(ApplicationStopPreparing)) {
-                SelftestGenerator.stop()
-            }
-
             routing {
                 route(config.contextpath) {
                     route("internal") {


### PR DESCRIPTION
hovedbolken av arbeidet som gjøres med å sjekke ett endepunkt gjøres før rapportering (evt vha ping-funksjonen), og det er derfor ikke behov for asynkronitet i selve rapporteringen.
