### PR TITLE
[KAIZEN-0] legge til støtte for å konfigurere hvordan scientist experiment kan flyttes mellom tråder

### DIFF
--- a/science/pom.xml
+++ b/science/pom.xml
@@ -37,6 +37,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.navikt.modia-common-utils</groupId>
+            <artifactId>kotlin-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>compile</scope>

--- a/science/src/main/kotlin/no/nav/personoversikt/common/science/scientist/Scientist.kt
+++ b/science/src/main/kotlin/no/nav/personoversikt/common/science/scientist/Scientist.kt
@@ -17,8 +17,9 @@ object Scientist {
     data class Config(
         val name: String,
         val rate: Rate,
+        val threadSwappingFn: (() -> Any?) -> (() -> Any?) = { it },
         val reporter: Reporter = defaultReporter,
-        val logAndCompareValues: Boolean = true
+        val logAndCompareValues: Boolean = true,
     )
 
     data class Result<T>(


### PR DESCRIPTION
kjøring av `control` og `experiment` gjøres i parallell, så man må kunne sikre at all informasjon (e.g ThreadLocal etc) blir flyttet med til de nye trådene før kjøring.

Dette kan nå gjøres ved å konfigurere `threadSwappingFn`, som kan bruke hjelpe-funksjoner fra concurrency-pakken, e.g `threadSwappingFn = myThreadLocal::makeTransferable`
