### PR TITLE
Lag dual logger som logger til både securelog og teamlog

### DIFF
--- a/logging/src/main/kotlin/no/nav/personoversikt/common/logging/Logging.kt
+++ b/logging/src/main/kotlin/no/nav/personoversikt/common/logging/Logging.kt
@@ -8,7 +8,47 @@ import org.slf4j.MarkerFactory
 object Logging {
     const val LOGTYPE_KEY = "logtype"
     val TEAM_LOGS_MARKER: Marker = MarkerFactory.getMarker("TEAM_LOGS")
-    val secureLog: Logger = LoggerFactory.getLogger("SecureLog")
+    private val faktiskSecureLog: Logger = LoggerFactory.getLogger("SecureLog")
+
     val auditLog: Logger = LoggerFactory.getLogger("AuditLogger")
     val teamLog: Logger = LoggerFactory.getLogger("TeamLog")
+    val secureLog: Logger = DualLogger(faktiskSecureLog, teamLog, TEAM_LOGS_MARKER)
+
+    // Logger til både secureLog og teamLog parallelt ved kall til secureLog.
+    // Dette kan fjernes når secureLog skal fases ut.
+
+    private class DualLogger(
+        private val secureLog: Logger,
+        private val teamLog: Logger,
+        private val teamLogMarker: Marker,
+    ) : Logger by secureLog {
+        override fun info(
+            marker: Marker?,
+            msg: String?,
+            t: Throwable?,
+        ) = logToBoth { p, s ->
+            p.info(marker, msg, t)
+            s.info(teamLogMarker, msg, t)
+        }
+
+        override fun warn(
+            marker: Marker?,
+            msg: String?,
+            t: Throwable?,
+        ) = logToBoth { p, s ->
+            p.warn(marker, msg, t)
+            s.warn(teamLogMarker, msg, t)
+        }
+
+        override fun error(
+            marker: Marker?,
+            msg: String?,
+            t: Throwable?,
+        ) = logToBoth { p, s ->
+            p.error(marker, msg, t)
+            s.error(teamLogMarker, msg, t)
+        }
+
+        private inline fun logToBoth(action: (Logger, Logger) -> Unit) = action(secureLog, teamLog)
+    }
 }

--- a/logging/src/main/kotlin/no/nav/personoversikt/common/logging/TjenestekallLogg.kt
+++ b/logging/src/main/kotlin/no/nav/personoversikt/common/logging/TjenestekallLogg.kt
@@ -46,7 +46,6 @@ interface TjenestekallLogger {
 
 object TjenestekallLogg : TjenestekallLogger {
     val raw = Logging.secureLog
-    val teamRaw = Logging.teamLog
     private val logtypemap = mutableMapOf<String, TjenestekallLogger>()
     private val separator = "-".repeat(84)
 
@@ -125,15 +124,6 @@ object TjenestekallLogg : TjenestekallLogger {
                 Level.ERROR -> raw::error
             }
         loggerFn(markers, message, throwable)
-
-        // Send logger til team logs parallell med secure logs i første omgang
-        val teamLoggerFn: (Marker?, String, Throwable?) -> Unit =
-            when (level) {
-                Level.INFO -> teamRaw::info
-                Level.WARN -> teamRaw::warn
-                Level.ERROR -> teamRaw::error
-            }
-        teamLoggerFn(Logging.TEAM_LOGS_MARKER, message, throwable)
     }
 
     fun format(


### PR DESCRIPTION
Det finnast nokon kall direkte til secureLog (ikkje via tjenestekallogg)

Istedenfor å kun endre tjenestekallloggen så vil all bruk av secureLog føre til parallell logging i securelog og teamlog.
Når securelog fases ut kan me velge å kun endre det her for all alle apper som tar i bruk denne dependencien for logging.